### PR TITLE
special case for arch x86_64 should be converted to amd64 for GOARCH …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PKG=github.com/guacsec/guac/pkg/version
 LDFLAGS="-X $(PKG).Version=$(VERSION) -X $(PKG).Commit=$(COMMIT) -X $(PKG).Date=$(BUILD)"
 
 CONTAINER ?= docker
-CPUTYPE=$(shell uname -m)
+CPUTYPE=$(shell uname -m | sed 's/x86_64/amd64/')
 GITHUB_REPOSITORY ?= guacsec/guac
 LOCAL_IMAGE_NAME ?= local-organic-guac
 


### PR DESCRIPTION
…consistency (#968)

# Description of the PR

<!-- Please include a summary of the change, including relevant motivation and context. -->

<!-- If this PR fixes an issue, please state this using "Fixes #XYZ" -->

# PR Checklist

- [ ] All commits have [a Developer Certificate of Origin (DCO)](https://wiki.linuxfoundation.org/dco) -- they are generated using `-s` flag to `git commit`.
- [ ] All new changes are covered by tests
- [ ] If GraphQL schema is changed, `make generate` has been run
- [ ] If `collectsub` protobuf has been changed, `make proto` has been run
- [ ] All CI checks are passing (tests and formatting)
- [ ] All dependent PRs have already been merged
